### PR TITLE
Expose styles as props

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,11 @@ const styles = StyleSheet.create({
 | renderYup         | Function | Renders Nope                                          | `true`  |
 | handleYup         | Function | Called when card is 'passed' with that card's data   |         |
 | handleNope        | Function | Called when card is 'rejected' with that card's data |         |
+| containerStyle    | style | Override default style                                  |         |
+| yupStyle          | style | Override default style                                  |         |
+| yupTextStyle      | style | Override default style                                  |         |
+| nopeStyle         | style | Override default style                                  |         |
+| nopeTextStyle     | style | Override default style                                  |         |
 
 *required
 

--- a/SwipeCards.js
+++ b/SwipeCards.js
@@ -18,6 +18,42 @@ import Defaults from './Defaults.js';
 
 var SWIPE_THRESHOLD = 120;
 
+// Base Styles. Use props to override these values
+var styles = StyleSheet.create({
+    container: {
+        flex: 1,
+        justifyContent: 'center',
+        alignItems: 'center',
+        backgroundColor: '#F5FCFF'
+    },
+    yup: {
+        borderColor: 'green',
+        borderWidth: 2,
+        position: 'absolute',
+        padding: 20,
+        bottom: 20,
+        borderRadius: 5,
+        right: 20,
+    },
+    yupText: {
+        fontSize: 16,
+        color: 'green',
+    },
+    nope: {
+        borderColor: 'red',
+        borderWidth: 2,
+        position: 'absolute',
+        bottom: 20,
+        padding: 20,
+        borderRadius: 5,
+        left: 20,
+    },
+    nopeText: {
+        fontSize: 16,
+        color: 'red',
+    }
+});
+
 class SwipeCards extends Component {
   constructor(props) {
     super(props);
@@ -220,41 +256,5 @@ SwipeCards.defaultProps = {
     nopeStyle: styles.nope,
     nopeTextStyle: styles.nopeText
 };
-
-// Base Styles. Use props to override these values
-var styles = StyleSheet.create({
-    container: {
-        flex: 1,
-        justifyContent: 'center',
-        alignItems: 'center',
-        backgroundColor: '#F5FCFF',
-    },
-    yup: {
-        borderColor: 'green',
-        borderWidth: 2,
-        position: 'absolute',
-        padding: 20,
-        bottom: 20,
-        borderRadius: 5,
-        right: 20,
-    },
-    yupText: {
-        fontSize: 16,
-        color: 'green',
-    },
-    nope: {
-        borderColor: 'red',
-        borderWidth: 2,
-        position: 'absolute',
-        bottom: 20,
-        padding: 20,
-        borderRadius: 5,
-        left: 20,
-    },
-    nopeText: {
-        fontSize: 16,
-        color: 'red',
-    }
-});
 
 export default SwipeCards

--- a/SwipeCards.js
+++ b/SwipeCards.js
@@ -231,9 +231,9 @@ SwipeCards.propTypes = {
     handleNope: React.PropTypes.func,
     containerStyle: View.PropTypes.style,
     yupStyle: View.PropTypes.style,
-    yupTextStyle: View.PropTypes.style,
+    yupTextStyle: Text.PropTypes.style,
     nopeStyle: View.PropTypes.style,
-    nopeTextStyle: View.PropTypes.style
+    nopeTextStyle: Text.PropTypes.style
 };
 
 SwipeCards.defaultProps = {

--- a/SwipeCards.js
+++ b/SwipeCards.js
@@ -19,222 +19,227 @@ import Defaults from './Defaults.js';
 var SWIPE_THRESHOLD = 120;
 
 class SwipeCards extends Component {
-  constructor(props) {
-    super(props);
+    constructor(props) {
+        super(props);
 
-    this.state = {
-      pan: new Animated.ValueXY(),
-      enter: new Animated.Value(0.5),
-      card: this.props.cards[0],
+        this.state = {
+            pan: new Animated.ValueXY(),
+            enter: new Animated.Value(0.5),
+            card: this.props.cards[0],
+        }
     }
-  }
 
-  _goToNextCard() {
-    let currentCardIdx = this.props.cards.indexOf(this.state.card);
-    let newIdx = currentCardIdx + 1;
+    _goToNextCard() {
+        let currentCardIdx = this.props.cards.indexOf(this.state.card);
+        let newIdx = currentCardIdx + 1;
 
-    // Checks to see if last card.
-    // If props.loop=true, will start again from the first card.
-    let card = newIdx > this.props.cards.length - 1
-      ? this.props.loop ? this.props.cards[0] : null
-      : this.props.cards[newIdx];
+        // Checks to see if last card.
+        // If props.loop=true, will start again from the first card.
+        let card = newIdx > this.props.cards.length - 1
+            ? this.props.loop ? this.props.cards[0] : null
+            : this.props.cards[newIdx];
 
-    this.setState({
-      card: card
-    });
-  }
+        this.setState({
+            card: card
+        });
+    }
 
-  componentDidMount() {
-    this._animateEntrance();
-  }
+    componentDidMount() {
+        this._animateEntrance();
+    }
 
-  _animateEntrance() {
-    Animated.spring(
-      this.state.enter,
-      { toValue: 1, friction: 8 }
-    ).start();
-  }
+    _animateEntrance() {
+        Animated.spring(
+            this.state.enter,
+            {toValue: 1, friction: 8}
+        ).start();
+    }
 
-  componentWillMount() {
-    this._panResponder = PanResponder.create({
-      onMoveShouldSetResponderCapture: () => true,
-      onMoveShouldSetPanResponderCapture: () => true,
+    componentWillMount() {
+        this._panResponder = PanResponder.create({
+            onMoveShouldSetResponderCapture: () => true,
+            onMoveShouldSetPanResponderCapture: () => true,
 
-      onPanResponderGrant: (e, gestureState) => {
-        this.state.pan.setOffset({x: this.state.pan.x._value, y: this.state.pan.y._value});
+            onPanResponderGrant: (e, gestureState) => {
+                this.state.pan.setOffset({x: this.state.pan.x._value, y: this.state.pan.y._value});
+                this.state.pan.setValue({x: 0, y: 0});
+            },
+
+            onPanResponderMove: Animated.event([
+                null, {dx: this.state.pan.x, dy: this.state.pan.y},
+            ]),
+
+            onPanResponderRelease: (e, {vx, vy}) => {
+                this.state.pan.flattenOffset();
+                var velocity;
+
+                if (vx >= 0) {
+                    velocity = clamp(vx, 3, 5);
+                } else if (vx < 0) {
+                    velocity = clamp(vx * -1, 3, 5) * -1;
+                }
+
+                if (Math.abs(this.state.pan.x._value) > SWIPE_THRESHOLD) {
+
+                    this.state.pan.x._value > 0
+                        ? this.props.handleYup(this.state.card)
+                        : this.props.handleNope(this.state.card)
+
+                    this.props.cardRemoved
+                        ? this.props.cardRemoved(this.props.cards.indexOf(this.state.card))
+                        : null
+
+                    Animated.decay(this.state.pan, {
+                        velocity: {x: velocity, y: vy},
+                        deceleration: 0.98
+                    }).start(this._resetState.bind(this))
+                } else {
+                    Animated.spring(this.state.pan, {
+                        toValue: {x: 0, y: 0},
+                        friction: 4
+                    }).start()
+                }
+            }
+        })
+    }
+
+    _resetState() {
         this.state.pan.setValue({x: 0, y: 0});
-      },
+        this.state.enter.setValue(0);
+        this._goToNextCard();
+        this._animateEntrance();
+    }
 
-      onPanResponderMove: Animated.event([
-        null, {dx: this.state.pan.x, dy: this.state.pan.y},
-      ]),
+    renderNoMoreCards() {
+        if (this.props.renderNoMoreCards)
+            return this.props.renderNoMoreCards();
 
-      onPanResponderRelease: (e, {vx, vy}) => {
-        this.state.pan.flattenOffset();
-        var velocity;
+        return (
+            <Defaults.NoMoreCards />
+        )
+    }
 
-        if (vx >= 0) {
-          velocity = clamp(vx, 3, 5);
-        } else if (vx < 0) {
-          velocity = clamp(vx * -1, 3, 5) * -1;
-        }
+    renderCard(cardData) {
+        return this.props.renderCard(cardData)
+    }
 
-        if (Math.abs(this.state.pan.x._value) > SWIPE_THRESHOLD) {
+    render() {
+        let {pan, enter,} = this.state;
 
-          this.state.pan.x._value > 0
-            ? this.props.handleYup(this.state.card)
-            : this.props.handleNope(this.state.card)
+        let [translateX, translateY] = [pan.x, pan.y];
 
-          this.props.cardRemoved
-            ? this.props.cardRemoved(this.props.cards.indexOf(this.state.card))
-            : null
+        let rotate = pan.x.interpolate({inputRange: [-200, 0, 200], outputRange: ["-30deg", "0deg", "30deg"]});
+        let opacity = pan.x.interpolate({inputRange: [-200, 0, 200], outputRange: [0.5, 1, 0.5]});
+        let scale = enter;
 
-          Animated.decay(this.state.pan, {
-            velocity: {x: velocity, y: vy},
-            deceleration: 0.98
-          }).start(this._resetState.bind(this))
-        } else {
-          Animated.spring(this.state.pan, {
-            toValue: {x: 0, y: 0},
-            friction: 4
-          }).start()
-        }
-      }
-    })
-  }
+        let animatedCardstyles = {transform: [{translateX}, {translateY}, {rotate}, {scale}], opacity};
 
-  _resetState() {
-    this.state.pan.setValue({x: 0, y: 0});
-    this.state.enter.setValue(0);
-    this._goToNextCard();
-    this._animateEntrance();
-  }
+        let yupOpacity = pan.x.interpolate({inputRange: [0, 150], outputRange: [0, 1]});
+        let yupScale = pan.x.interpolate({inputRange: [0, 150], outputRange: [0.5, 1], extrapolate: 'clamp'});
+        let animatedYupStyles = {transform: [{scale: yupScale}], opacity: yupOpacity}
 
-  renderNoMoreCards() {
-    if (this.props.renderNoMoreCards)
-      return this.props.renderNoMoreCards();
+        let nopeOpacity = pan.x.interpolate({inputRange: [-150, 0], outputRange: [1, 0]});
+        let nopeScale = pan.x.interpolate({inputRange: [-150, 0], outputRange: [1, 0.5], extrapolate: 'clamp'});
+        let animatedNopeStyles = {transform: [{scale: nopeScale}], opacity: nopeOpacity}
 
-    return (
-      <Defaults.NoMoreCards />
-    )
-  }
-
-  renderCard(cardData) {
-    return this.props.renderCard(cardData)
-  }
-
-  render() {
-    let { pan, enter, } = this.state;
-
-    let [translateX, translateY] = [pan.x, pan.y];
-
-    let rotate = pan.x.interpolate({inputRange: [-200, 0, 200], outputRange: ["-30deg", "0deg", "30deg"]});
-    let opacity = pan.x.interpolate({inputRange: [-200, 0, 200], outputRange: [0.5, 1, 0.5]});
-    let scale = enter;
-
-    let animatedCardstyles = {transform: [{translateX}, {translateY}, {rotate}, {scale}], opacity};
-
-    let yupOpacity = pan.x.interpolate({inputRange: [0, 150], outputRange: [0, 1]});
-    let yupScale = pan.x.interpolate({inputRange: [0, 150], outputRange: [0.5, 1], extrapolate: 'clamp'});
-    let animatedYupStyles = {transform: [{scale: yupScale}], opacity: yupOpacity}
-
-    let nopeOpacity = pan.x.interpolate({inputRange: [-150, 0], outputRange: [1, 0]});
-    let nopeScale = pan.x.interpolate({inputRange: [-150, 0], outputRange: [1, 0.5], extrapolate: 'clamp'});
-    let animatedNopeStyles = {transform: [{scale: nopeScale}], opacity: nopeOpacity}
-
-    return (
-      <View style={styles.container}>
-        { this.state.card
-            ? (
-            <Animated.View style={[styles.card, animatedCardstyles]} {...this._panResponder.panHandlers}>
-              {this.renderCard(this.state.card)}
-            </Animated.View>
-            )
-            : this.renderNoMoreCards() }
-
-
-        { this.props.renderNope
-          ? this.props.renderNope(pan)
-          : (
-              this.props.showNope
-              ? (
-                <Animated.View style={[styles.nope, animatedNopeStyles]}>
-                  <Text style={styles.nopeText}>Nope!</Text>
-                </Animated.View>
+        return (
+            <View style={this.props.containerStyle}>
+                { this.state.card
+                    ? (
+                    <Animated.View style={[styles.card, animatedCardstyles]} {...this._panResponder.panHandlers}>
+                        {this.renderCard(this.state.card)}
+                    </Animated.View>
                 )
-              : null
-            )
-        }
+                    : this.renderNoMoreCards() }
 
-        { this.props.renderYup
-          ? this.props.renderYup(pan)
-          : (
-              this.props.showYup
-              ? (
-                <Animated.View style={[styles.yup, animatedYupStyles]}>
-                  <Text style={styles.yupText}>Yup!</Text>
-                </Animated.View>
-              )
-              : null
-            )
-        }
 
-      </View>
-    );
-  }
+                { this.props.renderNope
+                    ? this.props.renderNope(pan)
+                    : (
+                    this.props.showNope
+                        ? (
+                        <Animated.View style={[this.props.nopeStyle, animatedNopeStyles]}>
+                            <Text style={this.props.nopeTextStyle}>Nope!</Text>
+                        </Animated.View>
+                    )
+                        : null
+                )
+                }
+
+                { this.props.renderYup
+                    ? this.props.renderYup(pan)
+                    : (
+                    this.props.showYup
+                        ? (
+                        <Animated.View style={[this.props.yupStyle, animatedYupStyles]}>
+                            <Text style={this.props.yupTextStyle}>Yup!</Text>
+                        </Animated.View>
+                    )
+                        : null
+                )
+                }
+
+            </View>
+        );
+    }
 }
 
 SwipeCards.propTypes = {
-  cards: React.PropTypes.array,
-  renderCards: React.PropTypes.func,
-  loop: React.PropTypes.bool,
-  renderNoMoreCards: React.PropTypes.func,
-  showYup: React.PropTypes.bool,
-  showNope: React.PropTypes.bool,
-  handleYup: React.PropTypes.func,
-  handleNope: React.PropTypes.func
+    cards: React.PropTypes.array,
+    renderCards: React.PropTypes.func,
+    loop: React.PropTypes.bool,
+    renderNoMoreCards: React.PropTypes.func,
+    showYup: React.PropTypes.bool,
+    showNope: React.PropTypes.bool,
+    handleYup: React.PropTypes.func,
+    handleNope: React.PropTypes.func
 };
 
 SwipeCards.defaultProps = {
-  loop: false,
-  showYup: true,
-  showNope: true
+    loop: false,
+    showYup: true,
+    showNope: true,
+    containerStyle: styles.container,
+    yupStyle: styles.yup,
+    yupTextStyle: styles.yupText,
+    nopeStyle: styles.nope,
+    nopeTextStyle: styles.nopeText
 };
 
 
 var styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-    backgroundColor: '#F5FCFF',
-  },
-  yup: {
-    borderColor: 'green',
-    borderWidth: 2,
-    position: 'absolute',
-    padding: 20,
-    bottom: 20,
-    borderRadius: 5,
-    right: 20,
-  },
-  yupText: {
-    fontSize: 16,
-    color: 'green',
-  },
-  nope: {
-    borderColor: 'red',
-    borderWidth: 2,
-    position: 'absolute',
-    bottom: 20,
-    padding: 20,
-    borderRadius: 5,
-    left: 20,
-  },
-  nopeText: {
-    fontSize: 16,
-    color: 'red',
-  }
+    container: {
+        flex: 1,
+        justifyContent: 'center',
+        alignItems: 'center',
+        backgroundColor: '#F5FCFF',
+    },
+    yup: {
+        borderColor: 'green',
+        borderWidth: 2,
+        position: 'absolute',
+        padding: 20,
+        bottom: 20,
+        borderRadius: 5,
+        right: 20,
+    },
+    yupText: {
+        fontSize: 16,
+        color: 'green',
+    },
+    nope: {
+        borderColor: 'red',
+        borderWidth: 2,
+        position: 'absolute',
+        bottom: 20,
+        padding: 20,
+        borderRadius: 5,
+        left: 20,
+    },
+    nopeText: {
+        fontSize: 16,
+        color: 'red',
+    }
 });
 
 export default SwipeCards

--- a/SwipeCards.js
+++ b/SwipeCards.js
@@ -229,11 +229,11 @@ SwipeCards.propTypes = {
     showNope: React.PropTypes.bool,
     handleYup: React.PropTypes.func,
     handleNope: React.PropTypes.func,
-    containerStyle: React.PropTypes.style,
-    yupStyle: React.PropTypes.style,
-    yupTextStyle: React.PropTypes.style,
-    nopeStyle: React.PropTypes.style,
-    nopeTextStyle: React.PropTypes.style
+    containerStyle: React.PropTypes.object,
+    yupStyle: React.PropTypes.object,
+    yupTextStyle: React.PropTypes.object,
+    nopeStyle: React.PropTypes.object,
+    nopeTextStyle: React.PropTypes.object
 };
 
 SwipeCards.defaultProps = {

--- a/SwipeCards.js
+++ b/SwipeCards.js
@@ -18,42 +18,6 @@ import Defaults from './Defaults.js';
 
 var SWIPE_THRESHOLD = 120;
 
-// Base Styles. Use props to override these values
-var styles = StyleSheet.create({
-    container: {
-        flex: 1,
-        justifyContent: 'center',
-        alignItems: 'center',
-        backgroundColor: '#F5FCFF',
-    },
-    yup: {
-        borderColor: 'green',
-        borderWidth: 2,
-        position: 'absolute',
-        padding: 20,
-        bottom: 20,
-        borderRadius: 5,
-        right: 20,
-    },
-    yupText: {
-        fontSize: 16,
-        color: 'green',
-    },
-    nope: {
-        borderColor: 'red',
-        borderWidth: 2,
-        position: 'absolute',
-        bottom: 20,
-        padding: 20,
-        borderRadius: 5,
-        left: 20,
-    },
-    nopeText: {
-        fontSize: 16,
-        color: 'red',
-    }
-});
-
 class SwipeCards extends Component {
   constructor(props) {
     super(props);
@@ -229,14 +193,14 @@ class SwipeCards extends Component {
 }
 
 SwipeCards.propTypes = {
-  cards: React.PropTypes.array,
-  renderCards: React.PropTypes.func,
-  loop: React.PropTypes.bool,
-  renderNoMoreCards: React.PropTypes.func,
-  showYup: React.PropTypes.bool,
-  showNope: React.PropTypes.bool,
-  handleYup: React.PropTypes.func,
-  handleNope: React.PropTypes.func, 
+    cards: React.PropTypes.array,
+    renderCards: React.PropTypes.func,
+    loop: React.PropTypes.bool,
+    renderNoMoreCards: React.PropTypes.func,
+    showYup: React.PropTypes.bool,
+    showNope: React.PropTypes.bool,
+    handleYup: React.PropTypes.func,
+    handleNope: React.PropTypes.func,
     yupText: React.PropTypes.string,
     noText: React.PropTypes.string,
     containerStyle: View.propTypes.style,
@@ -257,5 +221,40 @@ SwipeCards.defaultProps = {
     nopeTextStyle: styles.nopeText
 };
 
+// Base Styles. Use props to override these values
+var styles = StyleSheet.create({
+    container: {
+        flex: 1,
+        justifyContent: 'center',
+        alignItems: 'center',
+        backgroundColor: '#F5FCFF',
+    },
+    yup: {
+        borderColor: 'green',
+        borderWidth: 2,
+        position: 'absolute',
+        padding: 20,
+        bottom: 20,
+        borderRadius: 5,
+        right: 20,
+    },
+    yupText: {
+        fontSize: 16,
+        color: 'green',
+    },
+    nope: {
+        borderColor: 'red',
+        borderWidth: 2,
+        position: 'absolute',
+        bottom: 20,
+        padding: 20,
+        borderRadius: 5,
+        left: 20,
+    },
+    nopeText: {
+        fontSize: 16,
+        color: 'red',
+    }
+});
 
 export default SwipeCards

--- a/SwipeCards.js
+++ b/SwipeCards.js
@@ -58,20 +58,6 @@ class SwipeCards extends Component {
     constructor(props) {
         super(props);
 
-        // console.log(props)
-        // console.log(props.containerStyle)
-        // console.log(props.yupStyle)
-        //
-        // this.props.containerStyle = this.props.containerStyle || styles.container;
-        // this.props.yupStyle = this.props.yupStyle || styles.yupStyle;
-        // this.props.yupTextStyle = this.props.yupTextStyle || styles.yupTextStyle;
-        // this.props.nopeStyle = this.props.nopeStyle || styles.nopeStyle;
-        // this.props.nopeTextStyle = this.props.nopeTextStyle || styles.nopeTextStyle;
-        //
-        // console.log(props)
-        console.log(props.containerStyle)
-        console.log(props.yupStyle)
-
         this.state = {
             pan: new Animated.ValueXY(),
             enter: new Animated.Value(0.5),

--- a/SwipeCards.js
+++ b/SwipeCards.js
@@ -62,6 +62,16 @@ class SwipeCards extends Component {
         console.log(props.containerStyle)
         console.log(props.yupStyle)
 
+        this.props.containerStyle = this.props.containerStyle || styles.container;
+        this.props.yupStyle = this.props.yupStyle || styles.yupStyle;
+        this.props.yupTextStyle = this.props.yupTextStyle || styles.yupTextStyle;
+        this.props.nopeStyle = this.props.nopeStyle || styles.nopeStyle;
+        this.props.nopeTextStyle = this.props.nopeTextStyle || styles.nopeTextStyle;
+
+        console.log(props)
+        console.log(props.containerStyle)
+        console.log(props.yupStyle)
+
         this.state = {
             pan: new Animated.ValueXY(),
             enter: new Animated.Value(0.5),
@@ -243,12 +253,7 @@ SwipeCards.propTypes = {
 SwipeCards.defaultProps = {
     loop: false,
     showYup: true,
-    showNope: true,
-    containerStyle: styles.container,
-    yupStyle: styles.yup,
-    yupTextStyle: styles.yupText,
-    nopeStyle: styles.nope,
-    nopeTextStyle: styles.nopeText
+    showNope: true
 };
 
 export default SwipeCards

--- a/SwipeCards.js
+++ b/SwipeCards.js
@@ -58,6 +58,10 @@ class SwipeCards extends Component {
     constructor(props) {
         super(props);
 
+        console.log(props)
+        console.log(props.containerStyle)
+        console.log(props.yupStyle)
+
         this.state = {
             pan: new Animated.ValueXY(),
             enter: new Animated.Value(0.5),

--- a/SwipeCards.js
+++ b/SwipeCards.js
@@ -179,10 +179,10 @@ class SwipeCards extends Component {
         let animatedNopeStyles = {transform: [{scale: nopeScale}], opacity: nopeOpacity}
 
         return (
-            <View style={this.props.containerStyle}>
+            <View >
                 { this.state.card
                     ? (
-                    <Animated.View style={[styles.card, animatedCardstyles]} {...this._panResponder.panHandlers}>
+                    <Animated.View style={[animatedCardstyles]} {...this._panResponder.panHandlers}>
                         {this.renderCard(this.state.card)}
                     </Animated.View>
                 )
@@ -194,8 +194,8 @@ class SwipeCards extends Component {
                     : (
                     this.props.showNope
                         ? (
-                        <Animated.View style={[this.props.nopeStyle, animatedNopeStyles]}>
-                            <Text style={this.props.nopeTextStyle}>Nope!</Text>
+                        <Animated.View style={[animatedNopeStyles]}>
+                            <Text>Nope!</Text>
                         </Animated.View>
                     )
                         : null
@@ -207,8 +207,8 @@ class SwipeCards extends Component {
                     : (
                     this.props.showYup
                         ? (
-                        <Animated.View style={[this.props.yupStyle, animatedYupStyles]}>
-                            <Text style={this.props.yupTextStyle}>Yup!</Text>
+                        <Animated.View style={[animatedYupStyles]}>
+                            <Text >Yup!</Text>
                         </Animated.View>
                     )
                         : null

--- a/SwipeCards.js
+++ b/SwipeCards.js
@@ -18,6 +18,42 @@ import Defaults from './Defaults.js';
 
 var SWIPE_THRESHOLD = 120;
 
+// Base Styles. Use props to override these values
+var styles = StyleSheet.create({
+    container: {
+        flex: 1,
+        justifyContent: 'center',
+        alignItems: 'center',
+        backgroundColor: '#F5FCFF',
+    },
+    yup: {
+        borderColor: 'green',
+        borderWidth: 2,
+        position: 'absolute',
+        padding: 20,
+        bottom: 20,
+        borderRadius: 5,
+        right: 20,
+    },
+    yupText: {
+        fontSize: 16,
+        color: 'green',
+    },
+    nope: {
+        borderColor: 'red',
+        borderWidth: 2,
+        position: 'absolute',
+        bottom: 20,
+        padding: 20,
+        borderRadius: 5,
+        left: 20,
+    },
+    nopeText: {
+        fontSize: 16,
+        color: 'red',
+    }
+});
+
 class SwipeCards extends Component {
     constructor(props) {
         super(props);
@@ -210,41 +246,5 @@ SwipeCards.defaultProps = {
     nopeStyle: styles.nope,
     nopeTextStyle: styles.nopeText
 };
-
-
-var styles = StyleSheet.create({
-    container: {
-        flex: 1,
-        justifyContent: 'center',
-        alignItems: 'center',
-        backgroundColor: '#F5FCFF',
-    },
-    yup: {
-        borderColor: 'green',
-        borderWidth: 2,
-        position: 'absolute',
-        padding: 20,
-        bottom: 20,
-        borderRadius: 5,
-        right: 20,
-    },
-    yupText: {
-        fontSize: 16,
-        color: 'green',
-    },
-    nope: {
-        borderColor: 'red',
-        borderWidth: 2,
-        position: 'absolute',
-        bottom: 20,
-        padding: 20,
-        borderRadius: 5,
-        left: 20,
-    },
-    nopeText: {
-        fontSize: 16,
-        color: 'red',
-    }
-});
 
 export default SwipeCards

--- a/SwipeCards.js
+++ b/SwipeCards.js
@@ -229,11 +229,11 @@ SwipeCards.propTypes = {
     showNope: React.PropTypes.bool,
     handleYup: React.PropTypes.func,
     handleNope: React.PropTypes.func,
-    containerStyle: React.PropTypes.object,
-    yupStyle: React.PropTypes.object,
-    yupTextStyle: React.PropTypes.object,
-    nopeStyle: React.PropTypes.object,
-    nopeTextStyle: React.PropTypes.object
+    containerStyle: View.PropTypes.style,
+    yupStyle: View.PropTypes.style,
+    yupTextStyle: View.PropTypes.style,
+    nopeStyle: View.PropTypes.style,
+    nopeTextStyle: View.PropTypes.style
 };
 
 SwipeCards.defaultProps = {

--- a/SwipeCards.js
+++ b/SwipeCards.js
@@ -229,11 +229,11 @@ SwipeCards.propTypes = {
     showNope: React.PropTypes.bool,
     handleYup: React.PropTypes.func,
     handleNope: React.PropTypes.func,
-    containerStyle: View.PropTypes.style,
-    yupStyle: View.PropTypes.style,
-    yupTextStyle: Text.PropTypes.style,
-    nopeStyle: View.PropTypes.style,
-    nopeTextStyle: Text.PropTypes.style
+    containerStyle: View.propTypes.style,
+    yupStyle: View.propTypes.style,
+    yupTextStyle: Text.propTypes.style,
+    nopeStyle: View.propTypes.style,
+    nopeTextStyle: Text.propTypes.style
 };
 
 SwipeCards.defaultProps = {

--- a/SwipeCards.js
+++ b/SwipeCards.js
@@ -192,7 +192,12 @@ SwipeCards.propTypes = {
     showYup: React.PropTypes.bool,
     showNope: React.PropTypes.bool,
     handleYup: React.PropTypes.func,
-    handleNope: React.PropTypes.func
+    handleNope: React.PropTypes.func,
+    containerStyle: React.PropTypes.style,
+    yupStyle: React.PropTypes.style,
+    yupTextStyle: React.PropTypes.style,
+    nopeStyle: React.PropTypes.style,
+    nopeTextStyle: React.PropTypes.style
 };
 
 SwipeCards.defaultProps = {

--- a/SwipeCards.js
+++ b/SwipeCards.js
@@ -58,17 +58,17 @@ class SwipeCards extends Component {
     constructor(props) {
         super(props);
 
-        console.log(props)
-        console.log(props.containerStyle)
-        console.log(props.yupStyle)
-
-        this.props.containerStyle = this.props.containerStyle || styles.container;
-        this.props.yupStyle = this.props.yupStyle || styles.yupStyle;
-        this.props.yupTextStyle = this.props.yupTextStyle || styles.yupTextStyle;
-        this.props.nopeStyle = this.props.nopeStyle || styles.nopeStyle;
-        this.props.nopeTextStyle = this.props.nopeTextStyle || styles.nopeTextStyle;
-
-        console.log(props)
+        // console.log(props)
+        // console.log(props.containerStyle)
+        // console.log(props.yupStyle)
+        //
+        // this.props.containerStyle = this.props.containerStyle || styles.container;
+        // this.props.yupStyle = this.props.yupStyle || styles.yupStyle;
+        // this.props.yupTextStyle = this.props.yupTextStyle || styles.yupTextStyle;
+        // this.props.nopeStyle = this.props.nopeStyle || styles.nopeStyle;
+        // this.props.nopeTextStyle = this.props.nopeTextStyle || styles.nopeTextStyle;
+        //
+        // console.log(props)
         console.log(props.containerStyle)
         console.log(props.yupStyle)
 

--- a/SwipeCards.js
+++ b/SwipeCards.js
@@ -179,10 +179,10 @@ class SwipeCards extends Component {
         let animatedNopeStyles = {transform: [{scale: nopeScale}], opacity: nopeOpacity}
 
         return (
-            <View >
+            <View style={this.props.containerStyle}>
                 { this.state.card
                     ? (
-                    <Animated.View style={[animatedCardstyles]} {...this._panResponder.panHandlers}>
+                    <Animated.View style={[styles.card, animatedCardstyles]} {...this._panResponder.panHandlers}>
                         {this.renderCard(this.state.card)}
                     </Animated.View>
                 )
@@ -194,8 +194,8 @@ class SwipeCards extends Component {
                     : (
                     this.props.showNope
                         ? (
-                        <Animated.View style={[animatedNopeStyles]}>
-                            <Text>Nope!</Text>
+                        <Animated.View style={[this.props.nopeStyle, animatedNopeStyles]}>
+                            <Text style={this.props.nopeTextStyle}>Nope!</Text>
                         </Animated.View>
                     )
                         : null
@@ -207,8 +207,8 @@ class SwipeCards extends Component {
                     : (
                     this.props.showYup
                         ? (
-                        <Animated.View style={[animatedYupStyles]}>
-                            <Text >Yup!</Text>
+                        <Animated.View style={[this.props.yupStyle, animatedYupStyles]}>
+                            <Text style={this.props.yupTextStyle}>Yup!</Text>
                         </Animated.View>
                     )
                         : null
@@ -239,7 +239,12 @@ SwipeCards.propTypes = {
 SwipeCards.defaultProps = {
     loop: false,
     showYup: true,
-    showNope: true
+    showNope: true,
+    containerStyle: styles.container,
+    yupStyle: styles.yup,
+    yupTextStyle: styles.yupText,
+    nopeStyle: styles.nope,
+    nopeTextStyle: styles.nopeText
 };
 
 export default SwipeCards


### PR DESCRIPTION
I've exposed the styles as props, so that client code can customise the style of this library.

Note: Sorry I accidentally ran Webstorm's auto-formatted. The only code that changed was the default props, initial props, and the style code in the renderer.
