### PR TITLE
Add missing comma

### DIFF
--- a/SwipeCards.js
+++ b/SwipeCards.js
@@ -60,7 +60,7 @@ class SwipeCards extends Component {
 
     this.state = {
       pan: new Animated.ValueXY(),
-      enter: new Animated.Value(0.5)
+      enter: new Animated.Value(0.5),
       card: this.props.cards ? this.props.cards[0] : null,
     }
   }


### PR DESCRIPTION
I installed `0.0.8` and it throws an error due to the missing comma in [this line](https://github.com/meteor-factory/react-native-tinder-swipe-cards/blob/master/SwipeCards.js#L63), This commit fixes the error.
