### PR TITLE
Add ability to disallow gesture termination

### DIFF
--- a/SwipeCards.js
+++ b/SwipeCards.js
@@ -18,6 +18,8 @@ import Defaults from './Defaults.js';
 
 var SWIPE_THRESHOLD = 120;
 
+
+
 // Base Styles. Use props to override these values
 var styles = StyleSheet.create({
     container: {
@@ -111,6 +113,8 @@ class SwipeCards extends Component {
         this.state.pan.setValue({x: 0, y: 0});
       },
 
+      onPanResponderTerminationRequest: (evt, gestureState) => this.props.allowGestureTermination,
+      
       onPanResponderMove: Animated.event([
         null, {dx: this.state.pan.x, dy: this.state.pan.y},
       ]),
@@ -124,7 +128,7 @@ class SwipeCards extends Component {
         } else if (vx < 0) {
           velocity = clamp(vx * -1, 3, 5) * -1;
         }
-
+        
         if (Math.abs(this.state.pan.x._value) > SWIPE_THRESHOLD) {
 
           this.state.pan.x._value > 0
@@ -240,6 +244,7 @@ SwipeCards.propTypes = {
     cards: React.PropTypes.array,
     renderCards: React.PropTypes.func,
     loop: React.PropTypes.bool,
+    allowGestureTermination: React.PropTypes.bool,
     renderNoMoreCards: React.PropTypes.func,
     showYup: React.PropTypes.bool,
     showNope: React.PropTypes.bool,
@@ -261,6 +266,7 @@ SwipeCards.defaultProps = {
     loop: false,
     showYup: true,
     showNope: true,
+    allowGestureTermination: true,
     containerStyle: styles.container,
     yupStyle: styles.yup,
     yupTextStyle: styles.yupText,


### PR DESCRIPTION
If using this component along with NavigationCardStack then sliding a card to the left edge of the screen doesn't work anymore (i.e. the card just stays sat there when you take your finger off) because the PanHandler gesture gets terminated by the card stack's gesture controller wanting to take over gesture handling.

This PR adds an `enableGestureTermination` property (default = `true`). By setting this to `false` you can prevent the above from happening.