### PR TITLE
Fixed imports for the more complex example

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,9 @@ const styles = StyleSheet.create({
 ```javascript
 'use strict';
 
-import React, {StyleSheet, Text, View, Image} from 'react-native';
+import React from 'react';
+import {StyleSheet, Text, View, Image} from 'react-native';
+
 
 import SwipeCards from 'react-native-swipe-cards';
 


### PR DESCRIPTION
React API must be now required from react package (previously a warning
on 0.25)