### PR TITLE
Add getCurrentCard() method

### DIFF
--- a/SwipeCards.js
+++ b/SwipeCards.js
@@ -297,6 +297,13 @@ export default class SwipeCards extends Component {
     this._goToNextCard();
   }
 
+  /**
+   * Returns current card object
+   */
+  getCurrentCard() {
+      return this.state.cards[currentIndex[this.guid]];
+  }
+
   renderNoMoreCards() {
     if (this.props.renderNoMoreCards) {
       return this.props.renderNoMoreCards();


### PR DESCRIPTION
Add a method (getCurrentCard) to access current card object from component.

This is needed because the `currentIndex` var is outside the SwipeCard component, and so inaccessible from outside the file.

See #51 for my use case