### PR TITLE
taps on card will be recognized better

### DIFF
--- a/SwipeCards.js
+++ b/SwipeCards.js
@@ -127,7 +127,7 @@ export default class SwipeCards extends Component {
       onStartShouldSetPanResponderCapture: (e, gestureState) => {
         this.lastX = gestureState.moveX;
         this.lastY = gestureState.moveY;
-        return false;
+        return true;
       },
       onMoveShouldSetPanResponderCapture: (e, gestureState) => {
         return (Math.abs(this.lastX - gestureState.moveX) > 5 || Math.abs(this.lastY - gestureState.moveY) > 5);
@@ -147,7 +147,7 @@ export default class SwipeCards extends Component {
       onPanResponderRelease: (e, {vx, vy, dx, dy}) => {
         this.state.pan.flattenOffset();
         let velocity;
-        if ((dx === 0) && (dy === 0))   //meaning the gesture did not cover any distance
+        if (Math.abs(dx) <= 5 && Math.abs(dy) <= 5)   //meaning the gesture did not cover any distance
         {
           this.props.onClickHandler(this.state.card)
         }


### PR DESCRIPTION
in the old implementation the taps are hardly recognized. On the emulator it was quite impossible to get the click event triggered and an real smartphone customers said they needed 5-10 attempts.