### PR TITLE
Added missing NoMoreCards component to the README quick start example

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Note: Maybe action is optional
 // Tinder.js
 'use strict';
 
-import React from 'react';
+import React, { Component } from 'react';
 import {StyleSheet, Text, View, Image} from 'react-native';
 
 import SwipeCards from 'react-native-swipe-cards';
@@ -35,6 +35,20 @@ let Card = React.createClass({
     )
   }
 })
+
+class NoMoreCards extends Component {
+  constructor(props) {
+    super(props);
+  }
+
+  render() {
+    return (
+      <View>
+        <Text style={styles.noMoreCardsText}>No more cards</Text>
+      </View>
+    )
+  }
+}
 
 const Cards = [
   {text: 'Tomato', backgroundColor: 'red'},
@@ -86,6 +100,9 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     width: 300,
     height: 300,
+  },
+  noMoreCardsText: {
+    fontSize: 22,
   }
 })
 


### PR DESCRIPTION
When copying the quick example, the code eventually breaks when a user runs out of cards since NoMoreCards is not defined there. Added this component to the quick example to allow a user to reach the end.