### PR TITLE
Remove the T word

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,22 @@
-# Tinder Cards for React Native
+# Swipe Cards for React Native
 
-LOOKING FOR CONTRIBUTORS. I'm not currently using this in any active projects. If anyone wants to be added, please write me.
-
-A [package](https://www.npmjs.com/package/react-native-swipe-cards) based on [@brentvatne](https://github.com/brentvatne/)'s awesome [example](https://github.com/brentvatne/react-native-animated-demo-tinder), based in turn on the Tinder swipe interface.
+A [package](https://www.npmjs.com/package/react-native-swipe-cards) based on [@brentvatne](https://github.com/brentvatne/)'s awesome [example](https://github.com/brentvatne/react-native-animated-demo-tinder).
 
 
-![swiper-cards](https://github.com/esganzerla/react-native-tinder-swipe-cards/blob/handle-maybe/screenshots/swiper-cards.gif)
+!![React Native Swipe Cards](https://github.com/esganzerla/react-native-tinder-swipe-cards/blob/handle-maybe/screenshots/swiper-cards.gif)
 
 Note: Maybe action is optional
 
-![react native tinder cards pugs](https://raw.githubusercontent.com/meteor-factory/react-native-tinder-swipe-cards/master/screenshots/react-native-tinder-cards-pugs.gif)
+![React Native Swipe Cards Pugs](https://raw.githubusercontent.com/meteor-factory/react-native-tinder-swipe-cards/master/screenshots/react-native-tinder-cards-pugs.gif)
 
 ## Quick Start
 1. `npm install --save react-native-swipe-cards`
-2. Create a module e.g. `Tinder.js`
-3. Import it `import Tinder from './Tinder.js'`
-4. Render it `<Tinder style={{flex: 1}} />`
+2. Create a module e.g. `SwipeCards.js`
+3. Import it `import SwipeCards from './SwipeCards.js'`
+4. Render it `<SwipeCards style={{flex: 1}} />`
 
 ```javascript
-// Tinder.js
+// SwipeCards.js
 'use strict';
 
 import React, { Component } from 'react';

--- a/README.md
+++ b/README.md
@@ -3,11 +3,8 @@
 A [package](https://www.npmjs.com/package/react-native-swipe-cards) based on [@brentvatne](https://github.com/brentvatne/)'s awesome [example](https://github.com/brentvatne/react-native-animated-demo-tinder).
 
 
-!![React Native Swipe Cards](https://github.com/esganzerla/react-native-tinder-swipe-cards/blob/handle-maybe/screenshots/swiper-cards.gif)
-
-Note: Maybe action is optional
-
-![React Native Swipe Cards Pugs](https://raw.githubusercontent.com/meteor-factory/react-native-tinder-swipe-cards/master/screenshots/react-native-tinder-cards-pugs.gif)
+![React Native Swipe Cards](https://github.com/meteor-factory/react-native-tinder-swipe-cards/raw/master/screenshots/swiper-cards.gif
+)
 
 ## Quick Start
 1. `npm install --save react-native-swipe-cards`

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-swipe-cards",
   "version": "0.1.0",
-  "description": "Tinder style swipe cards for stylishly passing, failing a card",
+  "description": "Swipe cards for stylishly passing & failing a card",
   "main": "SwipeCards.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
@@ -10,12 +10,7 @@
     "type": "git",
     "url": "git+https://github.com/meteor-factory/react-native-tinder-swipe-cards.git"
   },
-  "keywords": [
-    "react-native",
-    "tinder",
-    "cards",
-    "swipe"
-  ],
+  "keywords": ["react-native", "tinder", "cards", "swipe"],
   "author": "meteor-factory",
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
Apparently [Tinder sends takedown notices](https://github.com/cwRichardKim/RKSwipeCards/commit/14e9d90c145e13b39a41d5eb48caa3643d923b37) so it's probably a good idea to remove all T references.

I also suggest this repo is renamed to `react-native-swipe-cards`. That's how it's published on NPM anyway.