### PR TITLE
Fix typo in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ const styles = StyleSheet.create({
 | yupView           | element  | React component to render on a Yes vote                     |              |
 | yupText           | string   | Text to render on Yes vote                                  | `Yep`        |
 | noView            | element  | React component to render on a No vote                      |              |
-| noText            | string   | Text to render on No vote                                   | `Nope`       |
+| nopeText          | string   | Text to render on No vote                                   | `Nope`       |
 | maybeView         | element  | React component to render on a Maybe vote                   |              |
 | maybeText         | string   | Text to render on Maybe vote                                | `Maybe`      |
 | smoothTransition  | Boolean  | Disables a slow transition fading the current card out      | `false`      |


### PR DESCRIPTION
`noText` props doesn't work, instead `nopeText` works.  Also, `noView` might be confusing since the others are  using `nope`!