### PR TITLE
enable configurable container styles via style prop

### DIFF
--- a/SwipeCards.js
+++ b/SwipeCards.js
@@ -537,7 +537,7 @@ export default class SwipeCards extends Component {
 
   render() {
     return (
-      <View style={styles.container}>
+      <View style={this.props.style}>
         {this.props.stack ? this.renderStack() : this.renderCard()}
         {this.renderNope()}
         {this.renderMaybe()}


### PR DESCRIPTION
all functionality was in place for configuring container styles but it was just circumvented at the end by explicitly setting the container styles to the defaults