### PR TITLE
Direction

### DIFF
--- a/SwipeCards.js
+++ b/SwipeCards.js
@@ -537,7 +537,7 @@ export default class SwipeCards extends Component {
 
   render() {
     return (
-      <View style={styles.container}>
+      <View style={this.props.style}>
         {this.props.stack ? this.renderStack() : this.renderCard()}
         {this.renderNope()}
         {this.renderMaybe()}

--- a/SwipeCards.js
+++ b/SwipeCards.js
@@ -369,7 +369,6 @@ export default class SwipeCards extends Component {
   }
 
   _advanceState(direction) {
-    console.log(direction);
     this.state.pan.setValue({ x: 0, y: 0 });
     this.state.enter.setValue(0);
     this._animateEntrance();


### PR DESCRIPTION
it would be nice to be able to control the direction of the flow of the cards. For example currently when you swipe right or left it progresses to the next card. it would be nice to be able to fix the direction of the flow so that if swipe in one direction it advances the current index card and in the other direction it retreats. Instead of Tinder think of iTunes album cover browser [see here](https://www.askdavetaylor.com/0-blog-pics/itunes-7-cover-view.png)