### PR TITLE
Locked prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ const styles = StyleSheet.create({
 | stackOffsetY      | Number   | Vertical offset between cards in stack                      | 0            |
 | cardRemoved       | Function | A callback passing the card reference that just got removed |              |
 | onClickHandler    | Function | A callback clicking the card                                 | alert('tap') |
-
+| locked            | Boolean  | Disables swiping and card movement                          | `false`      |
 
 
 

--- a/SwipeCards.js
+++ b/SwipeCards.js
@@ -158,6 +158,9 @@ export default class SwipeCards extends Component {
 
     this._panResponder = PanResponder.create({
       onMoveShouldSetPanResponderCapture: (e, gestureState) => {
+        if(this.props.locked){
+          return false;
+        }
         if (Math.abs(gestureState.dx) > 3 || Math.abs(gestureState.dy) > 3) {
           this.props.onDragStart();
           return true;


### PR DESCRIPTION
I have added a locked prop to disable card movement and swiping when true. This helped in my project, so I wanted to contribute in hopes it would help others. Cheers!

To use it, just add ```locked``` or ```locked={true}``` to your SwipeCards component.