### PR TITLE
useNativeDriver whenever possible

### DIFF
--- a/SwipeCards.js
+++ b/SwipeCards.js
@@ -174,7 +174,7 @@ export default class SwipeCards extends Component {
 
       onPanResponderMove: Animated.event([
         null, { dx: this.state.pan.x, dy: this.props.dragY ? this.state.pan.y : 0 },
-      ]),
+      ], { useNativeDriver: false }),
 
       onPanResponderRelease: (e, {vx, vy, dx, dy}) => {
         this.props.onDragRelease()
@@ -226,7 +226,8 @@ export default class SwipeCards extends Component {
           } else {
             this.cardAnimation = Animated.decay(this.state.pan, {
               velocity: { x: velocity, y: vy },
-              deceleration: 0.98
+              deceleration: 0.98,
+              useNativeDriver: true,
             });
             this.cardAnimation.start(status => {
               if (status.finished) this._advanceState();
@@ -247,39 +248,39 @@ export default class SwipeCards extends Component {
   _forceLeftSwipe() {
     this.cardAnimation = Animated.timing(this.state.pan, {
       toValue: { x: -500, y: 0 },
-    }).start(status => {
+      useNativeDriver: true,
+    }).start((status) => {
       if (status.finished) this._advanceState();
       else this._resetState();
 
       this.cardAnimation = null;
-    }
-      );
+    });
     this.props.cardRemoved(currentIndex[this.guid]);
   }
 
   _forceUpSwipe() {
     this.cardAnimation = Animated.timing(this.state.pan, {
       toValue: { x: 0, y: 500 },
-    }).start(status => {
+      useNativeDriver: true,
+    }).start((status) => {
       if (status.finished) this._advanceState();
       else this._resetState();
 
       this.cardAnimation = null;
-    }
-      );
+    });
     this.props.cardRemoved(currentIndex[this.guid]);
   }
 
   _forceRightSwipe() {
     this.cardAnimation = Animated.timing(this.state.pan, {
       toValue: { x: 500, y: 0 },
-    }).start(status => {
+      useNativeDriver: true,
+    }).start((status) => {
       if (status.finished) this._advanceState();
       else this._resetState();
 
       this.cardAnimation = null;
-    }
-      );
+    });
     this.props.cardRemoved(currentIndex[this.guid]);
   }
 
@@ -319,10 +320,11 @@ export default class SwipeCards extends Component {
   }
 
   _animateEntrance() {
-    Animated.spring(
-      this.state.enter,
-      { toValue: 1, friction: 8 }
-    ).start();
+    Animated.spring(this.state.enter, {
+      toValue: 1,
+      friction: 8,
+      useNativeDriver: true,
+    }).start();
   }
 
   componentWillReceiveProps(nextProps) {
@@ -344,7 +346,8 @@ export default class SwipeCards extends Component {
   _resetPan() {
     Animated.spring(this.state.pan, {
       toValue: { x: 0, y: 0 },
-      friction: 4
+      friction: 4,
+      useNativeDriver: true,
     }).start();
   }
 


### PR DESCRIPTION
Configure Animted to useNativeDriver whenever possible to:
1. Improve animation performance
2. Remove useNativeDriver not set warnings